### PR TITLE
fix(release): include `dist` folder in published artifact to NPM

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -20,6 +20,7 @@ jobs:
         with:
           cache: 'pnpm'
       - run: pnpm install
+      - run: pnpm build
       - name: Semantic Release
         run: pnpm release
         env:

--- a/.releaserc
+++ b/.releaserc
@@ -1,6 +1,28 @@
 plugins:
   - '@semantic-release/commit-analyzer'
-  - '@semantic-release/release-notes-generator'
+  - [
+      '@semantic-release/release-notes-generator',
+      {
+        preset: 'conventionalcommits',
+        presetConfig:
+          {
+            types:
+              [
+                { type: 'feat', section: 'Features' },
+                { type: 'fix', section: 'Bug Fixes' },
+                { type: 'perf', section: 'Performance Improvements' },
+                { type: 'revert', section: 'Reverts' },
+                { type: 'refactor', section: 'Refactor' },
+                { type: 'build', section: 'Internal' },
+                { type: 'chore', section: 'Internal' },
+                { type: 'ci', section: 'Internal' },
+                { type: 'docs', section: 'Internal' },
+                { type: 'style', section: 'Internal' },
+                { type: 'test', section: 'Internal' },
+              ],
+          },
+      },
+    ]
   - '@semantic-release/changelog'
   - '@semantic-release/npm'
   - '@semantic-release/git'

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
   "author": "Hussard <adrien.ricartnoblet@gmail.com>",
   "main": "dist/index.js",
   "files": [
-    "/dist"
+    "/dist",
+    "!*/__tests__"
   ],
   "scripts": {
     "build": "tsc",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,9 @@
   "license": "MIT",
   "author": "Hussard <adrien.ricartnoblet@gmail.com>",
   "main": "dist/index.js",
+  "files": [
+    "/dist"
+  ],
   "scripts": {
     "build": "tsc",
     "lint": "eslint .",

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "@types/mocha": "^10.0.1",
     "@typescript-eslint/eslint-plugin": "^5.59.2",
     "@typescript-eslint/parser": "^5.59.2",
+    "conventional-changelog-conventionalcommits": "^5.0.0",
     "eslint": "^8.39.0",
     "eslint-config-airbnb": "^19.0.4",
     "eslint-config-airbnb-typescript": "^17.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -51,6 +51,9 @@ devDependencies:
   '@typescript-eslint/parser':
     specifier: ^5.59.2
     version: 5.59.2(eslint@8.39.0)(typescript@5.0.4)
+  conventional-changelog-conventionalcommits:
+    specifier: ^5.0.0
+    version: 5.0.0
   eslint:
     specifier: ^8.39.0
     version: 8.39.0
@@ -1868,6 +1871,15 @@ packages:
     engines: {node: '>=10'}
     dependencies:
       compare-func: 2.0.0
+      q: 1.5.1
+    dev: true
+
+  /conventional-changelog-conventionalcommits@5.0.0:
+    resolution: {integrity: sha512-lCDbA+ZqVFQGUj7h9QBKoIpLhl8iihkO0nCTyRNzuXtcd7ubODpYB04IFy31JloiJgG0Uovu8ot8oxRzn7Nwtw==}
+    engines: {node: '>=10'}
+    dependencies:
+      compare-func: 2.0.0
+      lodash: 4.17.21
       q: 1.5.1
     dev: true
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,13 +10,8 @@
     "outDir": "dist",
     "preserveConstEnums": true,
     "removeComments": true,
-    "sourceMap": true,
     "target": "es6"
   },
-  "exclude": [
-    "node_modules"
-  ],
-  "include": [
-    "src/**/*.ts"
-  ] 
+  "exclude": ["node_modules"],
+  "include": ["src/**/*.ts"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,6 +10,7 @@
     "outDir": "dist",
     "preserveConstEnums": true,
     "removeComments": true,
+    "sourceMap": true,
     "target": "es6"
   },
   "exclude": ["node_modules"],


### PR DESCRIPTION
Fix the release workflow to:
- properly compile TS
- white-list the `dist` directory in the NPM package (see https://medium.com/@jdxcode/for-the-love-of-god-dont-use-npmignore-f93c08909d8d, https://codeburst.io/what-really-gets-packaged-f2b49397c2a5, https://blog.npmjs.org/post/165769683050/publishing-what-you-mean-to-publish.html)

To expand the CHANGELOG, had to:
- change from angular to conventionalcommits preset
- repeat the entire default value: https://github.com/conventional-changelog/conventional-changelog/blob/master/packages/conventional-changelog-conventionalcommits/writer-opts.js#L182
https://github.com/semantic-release/commit-analyzer/issues/233